### PR TITLE
Updated rich dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.7"
 click = "^8.0"
-rich = "^10.0"
+rich = ">=10.0,<13.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.10b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,12 @@ authors = ["Daylin Morgan <daylinmorgan@gmail.com>"]
 repository = "https://github.com/daylinmorgan/click-rich-help"
 readme = "README.md"
 license = "MIT"
-include = [
-    "LICENSE.txt"
-]
+include = ["LICENSE.txt"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
 click = "^8.0"
-rich = ">=10.0,<13.0"
+rich = ">=10.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.10b0"


### PR DESCRIPTION
Updated rich version dependency to `rich = ">=10.0,<13.0"`.  Tested with rich 10.14.0, 11.2.0 and 12.0.0.  Fixes #1 